### PR TITLE
Add the Ansible hosname option "use" for specific update strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ A role for managing the fqdn/hostname.
 |----------|-------------|---------------|
 | `fqdn_full` | Fully qualified domain name | `inventory_hostname` |
 | `fqdn_short` | Short hostname | `inventory_hostname_short` |
+| `fqdn_update_strategy` | Ansible hostname update strategy | `systemd` |
 
 ## Dependencies
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,3 +1,7 @@
 ---
 fqdn_full: "{{ inventory_hostname }}"
 fqdn_short: "{{ inventory_hostname_short }}"
+
+# Set a hostname specifying strategy 
+#  https://docs.ansible.com/ansible/latest/collections/ansible/builtin/hostname_module.html
+fqdn_update_strategy: "systemd"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,6 @@
 fqdn_full: "{{ inventory_hostname }}"
 fqdn_short: "{{ inventory_hostname_short }}"
 
-# Set a hostname specifying strategy 
+# Ansible Hostname module option to set specific update strategy
 #  https://docs.ansible.com/ansible/latest/collections/ansible/builtin/hostname_module.html
 fqdn_update_strategy: "systemd"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -10,6 +10,7 @@
 - name: Set Hostname
   hostname:
     name: "{{ fqdn_short }}"
+    use: "{{ fqdn_update_strategy }}"
 
 - name: Re-gather facts
   action: setup


### PR DESCRIPTION
I had to use this for a specific use case with a DietPi host, a damn small Debian like Linux. On DietPi the hostname module fails to update with systemd strategies (has to do with missing dbus functionalities). This option is meant to specify other strategies. On DietPi i had to set alpine instead.

https://docs.ansible.com/ansible/latest/collections/ansible/builtin/hostname_module.html